### PR TITLE
Add apiVersion to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ import PicoSanity from 'picosanity'
 const client = new PicoSanity({
   projectId: 'myProjectId',
   dataset: 'myDataset',
+  apiVersion: '2021-03-25', // use a UTC date string
   useCdn: true,
 })
 

--- a/src/client.js
+++ b/src/client.js
@@ -38,9 +38,10 @@ PicoSanity.prototype.fetch = function (query, params) {
   const cfg = this.clientConfig
   const headers = cfg.token ? {Authorization: `Bearer ${cfg.token}`} : undefined
   const host = !cfg.useCdn || cfg.token ? apiHost : cdnHost
+  const version = cfg.apiVersion ? 'v1' : 'v' + cfg.apiVersion
   const opts = {credentials: cfg.withCredentials ? 'include' : 'omit', headers}
   const qs = getQs(query, params)
-  return this.fetcher(`https://${cfg.projectId}.${host}/v1/data/query/${cfg.dataset}${qs}`, opts)
+  return this.fetcher(`https://${cfg.projectId}.${host}/${version}/data/query/${cfg.dataset}${qs}`, opts)
     .then((res) => res.json())
     .then((res) => res.result)
 }


### PR DESCRIPTION
As newly introduced by Content Lake: https://www.sanity.io/docs/js-client#api

Just a reminder: `next-sanity` depends on this too, so potentially will require a version bump here https://github.com/sanity-io/next-sanity/blob/main/package.json#L32, too